### PR TITLE
Challenge #3c: Fault Tolerant Broadcast

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,10 +68,10 @@ type UnansweredNodeBroadcast struct {
 
 func main() {
 	var messages []uint64
-	var topology map[string][]string
 	var unansweredNodeBroadcasts []UnansweredNodeBroadcast
 	// Prevent race condition on shared unansweredNodeBroadcasts access
 	var unansweredNodeBroadcastsMutex sync.Mutex
+	var destinations []string
 	// Prevent race conditions when writing messages
 	var messagesMutex sync.Mutex
 
@@ -217,7 +217,8 @@ func main() {
 			return err
 		}
 
-		topology = body.Topology
+		// Only store the destinations for our node
+		destinations = body.Topology[n.ID()]
 
 		return n.Reply(msg, TopologyResponseBody{
 			Type: "topology_ok",


### PR DESCRIPTION
Replaces #1 

From https://fly.io/dist-sys/3c/

> # Specification
> Your node should propagate values it sees from broadcast messages to the other nodes in the cluster—even in the face of network partitions! Values should propagate to all other nodes by the end of the test. Nodes should only return copies of their own local values.
> 
> # Evaluation
> Build your Go binary as maelstrom-broadcast and run it against Maelstrom with the following command:
>
> ```bash
> ./maelstrom test -w broadcast --bin ~/go/bin/maelstrom-broadcast --node-count 5 --time-limit 20 --rate 10 --nemesis partition
> ```
> This will run a 5-node cluster like before, but this time with a failing network! Fun!
